### PR TITLE
Update DAQModuleHelper method names (changed on appfwk develop)

### DIFF
--- a/plugins/FakeHSIEventGenerator.cpp
+++ b/plugins/FakeHSIEventGenerator.cpp
@@ -58,7 +58,7 @@ void
 FakeHSIEventGenerator::init(const nlohmann::json& init_data)
 {
   TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << get_name() << ": Entering init() method";
-  m_raw_hsi_data_sender = get_iom_sender<HSI_FRAME_STRUCT>(appfwk::connection_inst(init_data, "output"));
+  m_raw_hsi_data_sender = get_iom_sender<HSI_FRAME_STRUCT>(appfwk::connection_uid(init_data, "output"));
   TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << get_name() << ": Exiting init() method";
 }
 

--- a/plugins/HSIReadout.cpp
+++ b/plugins/HSIReadout.cpp
@@ -66,7 +66,7 @@ void
 HSIReadout::init(const nlohmann::json& init_data)
 {
   TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << get_name() << ": Entering init() method";
-  m_raw_hsi_data_sender = get_iom_sender<HSI_FRAME_STRUCT>(appfwk::connection_inst(init_data, "output"));
+  m_raw_hsi_data_sender = get_iom_sender<HSI_FRAME_STRUCT>(appfwk::connection_uid(init_data, "output"));
   TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << get_name() << ": Exiting init() method";
 }
 


### PR DESCRIPTION
v3.2.x added some calls to `appfwk::connection_inst`, but in the meantime, the name of the method was changed to `appfwk::connection_uid` in `develop`.