### PR TITLE
Updated default value for clock frequency to 62.5 MHz

### DIFF
--- a/schema/hsilibs/fakehsieventgenerator.jsonnet
+++ b/schema/hsilibs/fakehsieventgenerator.jsonnet
@@ -17,7 +17,7 @@ local types = {
    
     conf: s.record("Conf", [
 
-      s.field("clock_frequency", self.u64, 50000000,
+      s.field("clock_frequency", self.u64, 62500000,
         doc="Assumed clock frequency in Hz (for current-timestamp estimation)"),
 
       s.field("timestamp_offset", self.i64, 0,


### PR DESCRIPTION
The full set of repositories that are affected by this change is contained in the following list

```
git clone https://github.com/DUNE-DAQ/daqconf.git -b kbiery/62.5MHz_defaults
git clone https://github.com/DUNE-DAQ/dfmodules.git -b kbiery/62.5MHz_defaults
git clone https://github.com/DUNE-DAQ/dqm.git -b kbiery/62.5MHz_defaults
git clone https://github.com/DUNE-DAQ/flxlibs.git -b kbiery/62.5MHz_defaults
git clone https://github.com/DUNE-DAQ/hdf5libs.git -b kbiery/62.5MHz_defaults
git clone https://github.com/DUNE-DAQ/hsilibs.git -b kbiery/62.5MHz_defaults
git clone https://github.com/DUNE-DAQ/listrev.git -b kbiery/62.5MHz_defaults
git clone https://github.com/DUNE-DAQ/readoutmodules.git -b kbiery/62.5MHz_defaults
git clone https://github.com/DUNE-DAQ/timinglibs.git -b kbiery/62.5MHz_defaults
git clone https://github.com/DUNE-DAQ/trigger.git -b kbiery/62.5MHz_defaults
git clone https://github.com/DUNE-DAQ/triggeralgs.git -b kbiery/62.5MHz_defaults
git clone https://github.com/DUNE-DAQ/wibmod.git -b kbiery/62.5MHz_defaults
```

Recall that this first step in the deprecation of legacy hardware is simply switching to a default clock frequency of 62.5 MHz in our scripts, etc.  More changes will come later.