### PR TITLE
Changes to verify that the HSIEvent Sender is really ready to send messages before completing the 'start' transition

### DIFF
--- a/include/hsilibs/HSIEventSender.hpp
+++ b/include/hsilibs/HSIEventSender.hpp
@@ -62,6 +62,7 @@ protected:
   std::shared_ptr<hsievent_sender_ct> m_hsievent_sender;
 
   // push events to HSIEvent output queue
+  virtual bool ready_to_send(std::chrono::milliseconds timeout);
   virtual void send_hsi_event(dfmessages::HSIEvent& event);
   virtual void send_raw_hsi_data(const std::array<uint32_t, 7>& raw_data, raw_sender_ct* sender);
 

--- a/include/hsilibs/Issues.hpp
+++ b/include/hsilibs/Issues.hpp
@@ -36,6 +36,13 @@ ERS_DECLARE_ISSUE_BASE(hsilibs,
                        ((std::string)name),
                        ((std::string)queueType))
 
+ERS_DECLARE_ISSUE_BASE(hsilibs,
+                       SenderReadyTimeout,
+                       appfwk::GeneralDAQModuleIssue,
+                       "Timeout waiting for the Sender for connection " << conn << " to be ready.",
+                       ((std::string)name),
+                       ((std::string)conn))
+
 ERS_DECLARE_ISSUE(hsilibs,                         ///< Namespace
                   UHALIssue,                          ///< Issue class name
                   " UHAL related issue: " << message, ///< Message

--- a/plugins/FakeHSIEventGenerator.cpp
+++ b/plugins/FakeHSIEventGenerator.cpp
@@ -141,19 +141,15 @@ FakeHSIEventGenerator::do_start(const nlohmann::json& obj)
   }
   m_run_number.store(start_params.run);
 
-  // 27-Sep-2023, KAB: wait until we are really ready to send messages (within reason)
-  TLOG() << "KAB000 " << __LINE__;
-  if (! ready_to_send(std::chrono::milliseconds(5))) {
-    TLOG() << "KAB001 " << __LINE__;
-    if (! ready_to_send(std::chrono::milliseconds(1000))) {
-      TLOG() << "KAB002 " << __LINE__;
-      if (! ready_to_send(std::chrono::milliseconds(1000))) {
-        TLOG() << "KAB003 " << __LINE__;
-        if (! ready_to_send(std::chrono::milliseconds(1000))) {
-          TLOG() << "KAB004 " << __LINE__;
-        }
-      }
+  // 27-Sep-2023, KAB: wait until we are really ready to send messages
+  if (! ready_to_send(std::chrono::milliseconds(1))) {
+    do {
+      TLOG() << get_name() << " Waiting for the Sender for the "
+	     <<  m_hsievent_send_connection << " connection to be ready to send messages.";
     }
+    while (! ready_to_send(std::chrono::milliseconds(1000)));
+    TLOG() << get_name() << " The Sender for the "
+	   <<  m_hsievent_send_connection << " connection is now ready.";
   }
 
   m_thread.start_working_thread("fake-tsd-gen");

--- a/plugins/FakeHSIEventGenerator.cpp
+++ b/plugins/FakeHSIEventGenerator.cpp
@@ -141,6 +141,21 @@ FakeHSIEventGenerator::do_start(const nlohmann::json& obj)
   }
   m_run_number.store(start_params.run);
 
+  // 27-Sep-2023, KAB: wait until we are really ready to send messages (within reason)
+  TLOG() << "KAB000 " << __LINE__;
+  if (! ready_to_send(std::chrono::milliseconds(5))) {
+    TLOG() << "KAB001 " << __LINE__;
+    if (! ready_to_send(std::chrono::milliseconds(1000))) {
+      TLOG() << "KAB002 " << __LINE__;
+      if (! ready_to_send(std::chrono::milliseconds(1000))) {
+        TLOG() << "KAB003 " << __LINE__;
+        if (! ready_to_send(std::chrono::milliseconds(1000))) {
+          TLOG() << "KAB004 " << __LINE__;
+        }
+      }
+    }
+  }
+
   m_thread.start_working_thread("fake-tsd-gen");
   TLOG() << get_name() << " successfully started";
   TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << get_name() << ": Exiting do_start() method";

--- a/src/HSIEventSender.cpp
+++ b/src/HSIEventSender.cpp
@@ -40,6 +40,13 @@ HSIEventSender::init(const nlohmann::json& init_data)
   m_hsievent_sender = get_iom_sender<dfmessages::HSIEvent>(m_hsievent_send_connection);
 }
 
+bool
+HSIEventSender::ready_to_send(std::chrono::milliseconds timeout)
+{
+  if (m_hsievent_sender == nullptr) {return false;}
+  return m_hsievent_sender->is_ready_for_sending(timeout);
+}
+
 void
 HSIEventSender::send_hsi_event(dfmessages::HSIEvent& event)
 {
@@ -50,7 +57,7 @@ HSIEventSender::send_hsi_event(dfmessages::HSIEvent& event)
   bool was_successfully_sent = false;
   while (!was_successfully_sent) {
     try {
-        dfmessages::HSIEvent event_copy(event);
+      dfmessages::HSIEvent event_copy(event);
       m_hsievent_sender->send(std::move(event_copy), m_queue_timeout);
       ++m_sent_counter;
       m_last_sent_timestamp.store(event.timestamp);


### PR DESCRIPTION
These are candidate changes that make use of [independent candidate changes in the `iomanager` repo](https://github.com/DUNE-DAQ/iomanager/pull/66).

The goal of these changes is to ensure that once a run is started, the FakeHSIEventGenerator is ready to start sending HSIEvents.  This will prevent problems sending HSIEvents in the `do_hsi_work()` method that are simply due to the Sender not being ready.

The 'forever' loop waiting for the Sender to be ready might be too aggressive, and that can certainly be softened.