### PR TITLE
Shorten the name of the op-mon info gathering thread to avoid complai…

### DIFF
--- a/plugins/HSIController.cpp
+++ b/plugins/HSIController.cpp
@@ -85,7 +85,7 @@ HSIController::do_configure(const nlohmann::json& data)
     throw timinglibs::UHALDeviceNameIssue(ERS_HERE, message.str(), exception);
   }
 
-  m_thread.start_working_thread("gather-hsi-op-mon-info");
+  m_thread.start_working_thread("gather-hsi-info");
 
   configure_hardware_or_recover_state<timinglibs::TimingEndpointNotReady>(data, "HSI endpoint", m_endpoint_state.load());
 


### PR DESCRIPTION
…nts from the pthread_setname_np call that actually sets the thread name (16-char limit with null terminator).