### PR TITLE
hsilibs oks database added

### DIFF
--- a/config/hsi.data.xml
+++ b/config/hsi.data.xml
@@ -1,0 +1,156 @@
+<?xml version="1.0" encoding="ASCII"?>
+
+<!-- oks-data version 2.2 -->
+
+
+<!DOCTYPE oks-data [
+  <!ELEMENT oks-data (info, (include)?, (comments)?, (obj)+)>
+  <!ELEMENT info EMPTY>
+  <!ATTLIST info
+      name CDATA #IMPLIED
+      type CDATA #IMPLIED
+      num-of-items CDATA #REQUIRED
+      oks-format CDATA #FIXED "data"
+      oks-version CDATA #REQUIRED
+      created-by CDATA #IMPLIED
+      created-on CDATA #IMPLIED
+      creation-time CDATA #IMPLIED
+      last-modified-by CDATA #IMPLIED
+      last-modified-on CDATA #IMPLIED
+      last-modification-time CDATA #IMPLIED
+  >
+  <!ELEMENT include (file)*>
+  <!ELEMENT file EMPTY>
+  <!ATTLIST file
+      path CDATA #REQUIRED
+  >
+  <!ELEMENT comments (comment)*>
+  <!ELEMENT comment EMPTY>
+  <!ATTLIST comment
+      creation-time CDATA #REQUIRED
+      created-by CDATA #REQUIRED
+      created-on CDATA #REQUIRED
+      author CDATA #REQUIRED
+      text CDATA #REQUIRED
+  >
+  <!ELEMENT obj (attr | rel)*>
+  <!ATTLIST obj
+      class CDATA #REQUIRED
+      id CDATA #REQUIRED
+  >
+  <!ELEMENT attr (data)*>
+  <!ATTLIST attr
+      name CDATA #REQUIRED
+      type (bool|s8|u8|s16|u16|s32|u32|s64|u64|float|double|date|time|string|uid|enum|class|-) "-"
+      val CDATA ""
+  >
+  <!ELEMENT data EMPTY>
+  <!ATTLIST data
+      val CDATA #REQUIRED
+  >
+  <!ELEMENT rel (ref)*>
+  <!ATTLIST rel
+      name CDATA #REQUIRED
+      class CDATA ""
+      id CDATA ""
+  >
+  <!ELEMENT ref EMPTY>
+  <!ATTLIST ref
+      class CDATA #REQUIRED
+      id CDATA #REQUIRED
+  >
+]>
+
+<oks-data>
+
+<info name="" type="" num-of-items="2" oks-format="data" oks-version="862f2957270" created-by="jr19588" created-on="kipper.phy.bris.ac.uk" creation-time="20240417T160310" last-modified-by="jr19588" last-modified-on="kipper.phy.bris.ac.uk" last-modification-time="20240417T160310"/>
+
+<include>
+ <file path="/home/jr19588/NFD_DEV_240507_C8/sourcecode/timinglibs/schema/timinglibs/timing.schema.xml" />
+ <file path="schema/coredal/dunedaq.schema.xml"/>
+</include>
+
+<obj class="DaqApplication" id="tmc">
+    <attr name="application_name" type="string" val="daq_application"/>
+</obj>
+
+<obj class="DaqApplication" id="thi">
+    <attr name="application_name" type="string" val="daq_application"/>
+</obj>
+
+<obj class="Session" id="test-session">
+    <attr name="use_connectivity_server" type="bool" val="1"/>
+    <attr name="connectivity_service_interval_ms" type="u32" val="2000"/>
+    <attr name="data_request_timeout_ms" type="u32" val="1000"/>
+    <attr name="data_rate_slowdown_factor" type="u32" val="1"/>
+    <attr name="rte_script" type="string" val="/home/jr19588/NFD_DEV_240514_C8/install/daq_app_rte.sh"/>
+    <rel name="environment">
+     <ref class="VariableSet" id="common-env"/>
+    </rel>
+    <rel name="segment" class="Segment" id="generated-segment"/>  
+</obj>                                                                              
+
+
+<obj class="Segment" id="generated-segment">
+    <rel name="applications">
+     <ref class="DaqApplication" id="tmc"/>
+     <ref class="DaqApplication" id="thi"/>
+    </rel>
+    <rel name="controller" class="RCApplication" id="my-controller"/>
+</obj>
+
+
+<obj class="ConnectionService" id="connectionservice">
+    <attr name="enabled" type="bool" val="1"/>
+    <attr name="application_name" type="string" val="gunicorn"/>
+    <attr name="commandline_parameters" type="string" val="--bind=0.0.0.0:15000 --workers=1 --worker-class=gthread --threads=2 --timeout=0 --pid=connectionservice_15000.pid connection-service.connection-flask:app"/>
+    <attr name="port" type="u16" val="15000"/>
+    <attr name="threads" type="u16" val="1"/>
+    <rel name="applicationEnvironment">
+     <ref class="VariableSet" id="consvc_ssh"/>
+    </rel>
+    <rel name="runs_on" class="VirtualHost" id="connectionservice"/>
+</obj>
+
+   <obj class="VariableSet" id="common-env">
+    <rel name="contains">
+     <ref class="Variable" id="DUNEDAQ_ERS_ERROR"/>
+     <ref class="Variable" id="DUNEDAQ_ERS_FATAL"/>
+     <ref class="Variable" id="DUNEDAQ_ERS_INFO"/>
+     <ref class="Variable" id="DUNEDAQ_ERS_VERBOSITY_LEVEL"/>
+     <ref class="Variable" id="DUNEDAQ_ERS_WARNING"/>
+     <ref class="Variable" id="DUNEDAQ_PARTITION"/>
+    </rel>
+   </obj>
+
+<obj class="VariableSet" id="daq_application_ssh">
+    <rel name="contains">
+     <ref class="Variable" id="CMD_FAC"/>
+     <ref class="Variable" id="CONNECTION_SERVER"/>
+     <ref class="Variable" id="DETCHANNELMAPS_SHARE"/>
+     <ref class="Variable" id="INFO_SVC"/>
+     <ref class="Variable" id="TIMING_SHARE"/>
+     <ref class="Variable" id="TRACE_FILE"/>
+    </rel>
+</obj>
+
+<obj class="TimingController" id="TimingController1">
+ <attr name="device_str" type="string" val="TEST_CTL"/>
+ <attr name="hardware_state_recovery_enabled" type="bool" val="1"/>
+ <attr name="timing_session_name" type="string" val="test"/>
+</obj>
+
+<obj class="HSIController" id="HSIController1">
+    <attr name="connections_file" type="string" val="timinglibs/config/.test_connections.xml"/>
+    <attr name="clock_frequency" type="string" val=""/>
+    <attr name="trigger_rate" type="string" val=""/>
+    <attr name="address" type="string" val=""/>
+    <attr name="partition" type="string" val=""/>
+    <attr name="control_hardware_io" type="string" val=""/>
+    <attr name="rising_edge_mask" type="string" val=""/>
+    <attr name="falling_edge_mask" type="string" val=""/>
+    <attr name="invert_edge_mask" type="string" val=""/>
+    <attr name="data_source" type="string" val=""/>
+</obj>
+
+</oks-data>

--- a/schema/hsilibs/hsi.schema.xml
+++ b/schema/hsilibs/hsi.schema.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="ASCII"?>
+
+<!-- oks-schema version 2.2 -->
+
+
+<!DOCTYPE oks-schema [
+  <!ELEMENT oks-schema (info, (include)?, (comments)?, (class)+)>
+  <!ELEMENT info EMPTY>
+  <!ATTLIST info
+      name CDATA #IMPLIED
+      type CDATA #IMPLIED
+      num-of-items CDATA #REQUIRED
+      oks-format CDATA #FIXED "schema"
+      oks-version CDATA #REQUIRED
+      created-by CDATA #IMPLIED
+      created-on CDATA #IMPLIED
+      creation-time CDATA #IMPLIED
+      last-modified-by CDATA #IMPLIED
+      last-modified-on CDATA #IMPLIED
+      last-modification-time CDATA #IMPLIED
+  >
+  <!ELEMENT include (file)+>
+  <!ELEMENT file EMPTY>
+  <!ATTLIST file
+      path CDATA #REQUIRED
+  >
+  <!ELEMENT comments (comment)+>
+  <!ELEMENT comment EMPTY>
+  <!ATTLIST comment
+      creation-time CDATA #REQUIRED
+      created-by CDATA #REQUIRED
+      created-on CDATA #REQUIRED
+      author CDATA #REQUIRED
+      text CDATA #REQUIRED
+  >
+  <!ELEMENT class (superclass | attribute | relationship | method)*>
+  <!ATTLIST class
+      name CDATA #REQUIRED
+      description CDATA ""
+      is-abstract (yes|no) "no"
+  >
+  <!ELEMENT superclass EMPTY>
+  <!ATTLIST superclass name CDATA #REQUIRED>
+  <!ELEMENT attribute EMPTY>
+  <!ATTLIST attribute
+      name CDATA #REQUIRED
+      description CDATA ""
+      type (bool|s8|u8|s16|u16|s32|u32|s64|u64|float|double|date|time|string|uid|enum|class) #REQUIRED
+      range CDATA ""
+      format (dec|hex|oct) "dec"
+      is-multi-value (yes|no) "no"
+      init-value CDATA ""
+      is-not-null (yes|no) "no"
+      ordered (yes|no) "no"
+  >
+  <!ELEMENT relationship EMPTY>
+  <!ATTLIST relationship
+      name CDATA #REQUIRED
+      description CDATA ""
+      class-type CDATA #REQUIRED
+      low-cc (zero|one) #REQUIRED
+      high-cc (one|many) #REQUIRED
+      is-composite (yes|no) #REQUIRED
+      is-exclusive (yes|no) #REQUIRED
+      is-dependent (yes|no) #REQUIRED
+      ordered (yes|no) "no"
+  >
+  <!ELEMENT method (method-implementation*)>
+  <!ATTLIST method
+      name CDATA #REQUIRED
+      description CDATA ""
+  >
+  <!ELEMENT method-implementation EMPTY>
+  <!ATTLIST method-implementation
+      language CDATA #REQUIRED
+      prototype CDATA #REQUIRED
+      body CDATA ""
+  >
+]>
+
+<oks-schema>
+
+<info name="" type="" num-of-items="11" oks-format="schema" oks-version="862f2957270" created-by="dianaAntic" created-on="mu2edaq13.fnal.gov" creation-time="20230123T223700" last-modified-by="eflumerf" last-modified-on="ironvirt9.mshome.net" last-modification-time="20240325T173708"/>
+
+<include>
+ <file path="/home/jr19588/NFD_DEV_240507_C8/sourcecode/timinglibs/schema/timinglibs/timing.schema.xml"/>
+ <file path="schema/coredal/dunedaq.schema.xml"/>
+</include>
+
+</oks-schema>

--- a/test_config/.test_connections.xml
+++ b/test_config/.test_connections.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<connections>
+  <connection id="TEST_CTL"          uri="ipbusudp-2.0://192.168.200.16:50001" address_table="file://${TIMING_SHARE}/config/etc/addrtab/v7xx/master/top.xml" />
+  <connection id="TEST_EPT"          uri="ipbusudp-2.0://192.168.200.41:50001" address_table="file://${TIMING_SHARE}/config/etc/addrtab/v7xx/endpoint_fmc/top.xml" />
+</connections>

--- a/test_config/boot.json
+++ b/test_config/boot.json
@@ -1,0 +1,91 @@
+{
+    "apps": {
+        "thi": {
+            "exec": "daq_application_ssh",
+            "host": "thi",
+            "port": 3333
+        },
+        "tmc": {
+            "exec": "daq_application_ssh",
+            "host": "tmc",
+            "port": 3334
+        }
+    },
+    "env": {
+        "DUNEDAQ_ERS_DEBUG_LEVEL": "getenv_ifset",
+        "DUNEDAQ_ERS_ERROR": "erstrace,throttle,lstdout",
+        "DUNEDAQ_ERS_FATAL": "erstrace,lstdout",
+        "DUNEDAQ_ERS_INFO": "erstrace,throttle,lstdout",
+        "DUNEDAQ_ERS_VERBOSITY_LEVEL": "getenv:1",
+        "DUNEDAQ_ERS_WARNING": "erstrace,throttle,lstdout"
+    },
+    "exec": {
+        "consvc_ssh": {
+            "args": [
+                "--bind=0.0.0.0:{APP_PORT}",
+                "--workers=1",
+                "--worker-class=gthread",
+                "--threads=2",
+                "--timeout=0",
+                "--pid={APP_NAME}_{APP_PORT}.pid",
+                "connection-service.connection-flask:app"
+            ],
+            "cmd": "gunicorn",
+            "env": {
+                "CONNECTION_FLASK_DEBUG": "getenv:2",
+                "PATH": "getenv",
+                "PYTHONPATH": "getenv"
+            }
+        },
+        "daq_application_ssh": {
+            "args": [
+                "--name",
+                "{APP_NAME}",
+                "-c",
+                "{CMD_FAC}",
+                "-i",
+                "{INFO_SVC}",
+                "--configurationService",
+                "oksconfig:config/hsi.data.xml"
+            ],
+            "cmd": "daq_application",
+            "comment": "Application profile using PATH variables (lower start time)",
+            "env": {
+                "CET_PLUGIN_PATH": "getenv",
+                "CMD_FAC": "rest://localhost:{APP_PORT}",
+                "CONNECTION_SERVER": "kipper.phy.bris.ac.uk",
+                "DETCHANNELMAPS_SHARE": "getenv",
+                "DUNEDAQ_DB_PATH": "getenv",
+                "DUNEDAQ_SHARE_PATH": "getenv",
+                "INFO_SVC": "file://info_{APP_NAME}_{APP_PORT}.json",
+                "LD_LIBRARY_PATH": "getenv",
+                "PATH": "getenv",
+                "TIMING_SHARE": "getenv",
+                "TRACE_FILE": "getenv:/tmp/trace_buffer_{APP_HOST}_{DUNEDAQ_PARTITION}"
+            }
+        }
+    },
+    "external_connections": [],
+    "hosts-ctrl": {
+        "connectionservice": "kipper.phy.bris.ac.uk",
+        "thi": "kipper.phy.bris.ac.uk",
+        "tmc": "kipper.phy.bris.ac.uk"
+    },
+    "hosts-data": {
+        "thi": "kipper.phy.bris.ac.uk",
+        "tmc": "kipper.phy.bris.ac.uk"
+    },
+    "response_listener": {
+        "port": 56789
+    },
+    "services": {
+        "connectionservice": {
+            "exec": "consvc_ssh",
+            "host": "connectionservice",
+            "port": 5000,
+            "update-env": {
+                "CONNECTION_PORT": "{APP_PORT}"
+            }
+        }
+    }
+}


### PR DESCRIPTION
To verify the functionality of the OKS configuration, the testing of nanotimingrc on real hardware was required.

This PR adds the required database file for setting up the minimal OKS configuration for a successful RC run.

To test, I ran the following command on kipper in a recent work env NFD_DEV_240507_C8:
` nanotimingrc --partition-number 7 hsilibs/test_config/ test-session`
making sure that the name of the test session matches the name given in this object: <obj class="Session" id="test-session"> in the data file.
The folder boot.json file which contains the necessary setup for the RC run is included in the test_config/ folder alongside the `.test_connections.xml` file which contains links to the CTL/EPT electronics combinations set up in the lab in Bristol. 