### PR TITLE
Porting v4 changes to v4 - iceberg_real_hsi_test.py updates

### DIFF
--- a/integtest/iceberg_real_hsi_test.py
+++ b/integtest/iceberg_real_hsi_test.py
@@ -81,8 +81,14 @@ conf_dict["boot"]["connectivity_service_port"] = conn_svc_port
 conf_dict["detector"]["clock_speed_hz"] = 62500000
 conf_dict["readout"]["latency_buffer_size"] = 200000
 conf_dict["readout"]["use_fake_data_producers"] = True
-conf_dict["trigger"]["trigger_window_before_ticks"] = 1000
-conf_dict["trigger"]["trigger_window_after_ticks"] = 1000
+conf_dict["trigger"]["ttcm_input_map"] = [{'signal': 128, 'tc_type_name': 'kDTSPulser',
+                                           'time_before': 1000, 'time_after': 1000}]
+
+conf_dict["readout"]["data_files"] = []
+datafile_conf = {}
+datafile_conf["data_file"] = "asset://?checksum=e96fd6efd3f98a9a3bfaba32975b476e" # WIBEth
+datafile_conf["detector_id"] = 3
+conf_dict["readout"]["data_files"].append(datafile_conf)
 
 conf_dict["dataflow"]["apps"] = [] # Remove preconfigured dataflow0 app
 for df_app in range(number_of_dataflow_apps):
@@ -91,8 +97,6 @@ for df_app in range(number_of_dataflow_apps):
     conf_dict["dataflow"]["apps"].append(dfapp_conf)
 
 if we_are_running_on_an_iceberg_computer and the_global_timing_session_is_running and the_connection_server_is_running:
-    conf_dict["trigger"]["ttcm_s1"] = 128
-    conf_dict["trigger"]["hsi_trigger_type_passthrough"] = True
     conf_dict["hsi"]["random_trigger_rate_hz"] = base_trigger_rate
     conf_dict["hsi"]["control_hsi_hw"]= True
     conf_dict["hsi"]["hsi_device_name"]= "BOREAS_TLU_ICEBERG"


### PR DESCRIPTION
The goal of this Pull Request is to bring one of the changes that was only made in the v4 line of development into the v5 line.

These changes were ones to get the iceberg_real_hsi_test.py integtest working again.

NB: I don't expect this integtest to work initially in the v5 line.  So, some additional work is very likely to be needed.