### PR TITLE
Unit Tests for HSI_FRAME_STRUCT behavior in buffers/requests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,5 +62,7 @@ daq_add_plugin(HSIController duneDAQModule LINK_LIBRARIES hsilibs timing::timing
 
 ##############################################################################
 
+daq_add_unit_test(HSITypeAdapters_test LINK_LIBRARIES hsilibs ${BOOST_LIBS})
+
 ##############################################################################
 daq_install()

--- a/include/hsilibs/Types.hpp
+++ b/include/hsilibs/Types.hpp
@@ -55,6 +55,11 @@ public:
     frame.set_timestamp(ts);
   }
 
+  void fake_timestamps(uint64_t first_timestamp, uint64_t /*offset*/= 0 ) // NOLINT(build/unsigned)
+  {
+    frame.set_timestamp(first_timestamp);
+  }
+
   FrameType* begin() { return this; }
 
   FrameType* end() { return (this + 1); } // NOLINT
@@ -68,7 +73,7 @@ public:
   static const constexpr daqdataformats::SourceID::Subsystem subsystem =
     daqdataformats::SourceID::Subsystem::kHwSignalsInterface;
   static const constexpr daqdataformats::FragmentType fragment_type = daqdataformats::FragmentType::kHardwareSignal;
-  static const constexpr uint64_t expected_tick_difference = 0; // NOLINT(build/unsigned)
+  static const constexpr uint64_t expected_tick_difference = 1; // NOLINT(build/unsigned)
 };
 
 static_assert(sizeof(struct HSI_FRAME_STRUCT) == HSI_FRAME_STRUCT_SIZE,

--- a/unittest/HSITypeAdapters_test.cxx
+++ b/unittest/HSITypeAdapters_test.cxx
@@ -1,0 +1,36 @@
+/**
+ * @file HSITypeAdapters_test.cxx
+ *
+ * Unittest for testing lower bound and request handling on HSI_FRAME_STRUCT
+ *
+ * This is part of the DUNE DAQ Application Framework, copyright 2022.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+
+#define BOOST_TEST_MODULE HSITypeAdapters_test // NOLINT
+
+#include "hsilibs/Types.hpp"
+
+#include "datahandlinglibs/testutils/TestUtilities.hpp"
+#include "datahandlinglibs/models/BinarySearchQueueModel.hpp"
+
+#include "boost/test/unit_test.hpp"
+
+BOOST_AUTO_TEST_SUITE(HSITypeAdapters_test)
+
+BOOST_AUTO_TEST_CASE(TBinarySearchQueueModel_HSI_FRAME_STRUCT_TestQueue)
+{
+    dunedaq::datahandlinglibs::test::test_queue_model<
+            dunedaq::datahandlinglibs::BinarySearchQueueModel,
+            dunedaq::hsilibs::HSI_FRAME_STRUCT>();
+}
+BOOST_AUTO_TEST_CASE(TBinarySearchQueueModel_HSI_FRAME_STRUCT_TestRequest)
+{
+    dunedaq::datahandlinglibs::test::test_request_model<
+            dunedaq::datahandlinglibs::BinarySearchQueueModel,
+            dunedaq::hsilibs::HSI_FRAME_STRUCT>();
+}
+BOOST_AUTO_TEST_SUITE_END()
+
+


### PR DESCRIPTION
This PR implements unit tests using the common datahandlinglibs test functions that check the BinarySeachQueueModel<HSI_FRAME_STRUCT> buffer, with respect to returning the correct lower_bound behavior and to responding to requests to form fragments properly.

Note that this changes `HSI_FRAME_STRUCT::expected_tick_difference` from `0` to `1`, and adds a function used to fill all timestamps in a type adapter object (trivial here, as there's only one). The expected_tick_difference of 1 is used by the test functions to properly setup test buffers, but most importantly it is used in `DefaultRequestHandler::get_fragment_pieces` to get the fragment building logic correct. Changing from 0 to 1 should not be detrimental to the correct behavior ... though it perhaps is a little weird, and I think probes at some of the limitations of our model right now.

This PR needs https://github.com/DUNE-DAQ/datahandlinglibs/pull/27. With that pulled down, to run the unit tests, do
```
dbt-build --unittest hsilibs
```
 We should wait to merge this PR in until the datahandlibs PR has been approved and merged as well.