### PR TITLE
Include logging/Logging.hpp whenever ERS issues are declared, includi…

### DIFF
--- a/include/hsilibs/Issues.hpp
+++ b/include/hsilibs/Issues.hpp
@@ -14,7 +14,7 @@
 
 #include "appfwk/DAQModule.hpp"
 #include "ers/Issue.hpp"
-#include <logging/Logging.hpp> // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
+#include "logging/Logging.hpp" // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
 
 #include <string>
 

--- a/include/hsilibs/Issues.hpp
+++ b/include/hsilibs/Issues.hpp
@@ -14,6 +14,7 @@
 
 #include "appfwk/DAQModule.hpp"
 #include "ers/Issue.hpp"
+#include <logging/Logging.hpp> // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
 
 #include <string>
 

--- a/plugins/HSIReadout.cpp
+++ b/plugins/HSIReadout.cpp
@@ -14,7 +14,7 @@
 
 #include "hsilibs/opmon/hsi_readout_info.pb.cc"
 
-#include "logging/Logging.hpp"
+#include <logging/Logging.hpp> // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
 #include "rcif/cmd/Nljs.hpp"
 #include "confmodel/DaqModule.hpp"
 #include "confmodel/Connection.hpp"

--- a/plugins/HSIReadout.cpp
+++ b/plugins/HSIReadout.cpp
@@ -14,7 +14,7 @@
 
 #include "hsilibs/opmon/hsi_readout_info.pb.cc"
 
-#include <logging/Logging.hpp> // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
+#include "logging/Logging.hpp" // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
 #include "rcif/cmd/Nljs.hpp"
 #include "confmodel/DaqModule.hpp"
 #include "confmodel/Connection.hpp"


### PR DESCRIPTION
…ng note on why (TLOG() << ERSIssue only works when Logging.hpp included first)