### PR TITLE
Johnfreeman/merge fddaq v5.3.2 rc2 a9 into develop

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.12)
-project(hsilibs VERSION 4.6.1)
+project(hsilibs VERSION 4.7.0)
 
 find_package(daq-cmake REQUIRED)
 

--- a/include/hsilibs/Issues.hpp
+++ b/include/hsilibs/Issues.hpp
@@ -18,9 +18,6 @@
 
 #include <string>
 
-// NOLINTNEXTLINE(build/define_used)
-#define TLVL_ENTER_EXIT_METHODS 10
-
 namespace dunedaq {
 
 ERS_DECLARE_ISSUE_BASE(hsilibs,

--- a/plugins/FakeHSIEventGeneratorModule.cpp
+++ b/plugins/FakeHSIEventGeneratorModule.cpp
@@ -30,6 +30,12 @@
 namespace dunedaq {
 namespace hsilibs {
 
+enum
+{
+  TLVL_ENTER_EXIT_METHODS = 5
+};
+
+  
 FakeHSIEventGeneratorModule::FakeHSIEventGeneratorModule(const std::string& name)
   : HSIEventSender(name)
   , m_thread(std::bind(&FakeHSIEventGeneratorModule::do_hsi_work, this, std::placeholders::_1))

--- a/plugins/HSIDataHandlerModule.cpp
+++ b/plugins/HSIDataHandlerModule.cpp
@@ -58,19 +58,17 @@ HSIDataHandlerModule::init(std::shared_ptr<appfwk::ConfigurationManager> mcfg)
                     rol::BinarySearchQueueModel<hsilibs::HSI_FRAME_STRUCT>,
                     hsilibs::HSIFrameProcessor>>(m_run_marker);
   m_readout_impl->init(mcfg->get_dal<appmodel::DataHandlerModule>(get_name()));
+    
   if (m_readout_impl == nullptr)
   {
     TLOG() << get_name() << "Initialize HSIDataHandlerModule FAILED! ";
     throw datahandlinglibs::FailedReadoutInitialization(ERS_HERE, get_name(), "OKS Config"); // 4 json ident
   }
+
+  register_node( "data_handler", m_readout_impl);
+  
   TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << get_name() << ": Exiting init() method";
 }
-
-// void
-// HSIDataHandlerModule::get_info(opmonlib::InfoCollector& ci, int level)
-// {
-//   m_readout_impl->get_info(ci, level);
-// }
 
 void
 HSIDataHandlerModule::do_conf(const data_t& args)

--- a/plugins/HSIDataHandlerModule.hpp
+++ b/plugins/HSIDataHandlerModule.hpp
@@ -37,7 +37,6 @@ public:
   HSIDataHandlerModule& operator=(HSIDataHandlerModule&&) = delete;      ///< HSIDataHandlerModule is not move-assignable
 
   void init(std::shared_ptr<appfwk::ConfigurationManager> mcfg) override;
-  //  void get_info(opmonlib::InfoCollector& ci, int level) override;
 
 private:
   // Commands
@@ -52,7 +51,7 @@ private:
   daqdataformats::run_number_t m_run_number;
 
   // Internal
-  std::unique_ptr<datahandlinglibs::DataHandlingConcept> m_readout_impl;
+  std::shared_ptr<datahandlinglibs::DataHandlingConcept> m_readout_impl;
 
   // Threading
   std::atomic<bool> m_run_marker;


### PR DESCRIPTION
In light of the second fddaq-v5.3.2 candidate release, fddaq-v5.3.2-rc2-a9, this PR will merge in the changes from the patch/fddaq-v5.3.x branch of this repo (with any conflicts resolved, if needed, on this source branch for this PR
johnfreeman/merge_fddaq-v5.3.2-rc2-a9_into_develop). A test build using this branch is available at NFDT_DEV_250603_A9.

Merging is only to be done by Software Coordination.