### PR TITLE
Johnfreeman/new daq cmake for v5.3.x

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ find_package(oks REQUIRED)
 find_package(oksdalgen REQUIRED)
 find_package(conffwk REQUIRED)
 
-daq_oks_codegen(hsi.schema.xml NAMESPACE dunedaq::hsilibs::dal DALDIR dal DEP_PKGS timinglibs confmodel)
+add_dal_library(hsi.schema.xml NAMESPACE dunedaq::hsilibs::dal DALDIR dal DEP_PKGS timinglibs confmodel)
 
 daq_protobuf_codegen( opmon/*.proto )
 
@@ -57,14 +57,14 @@ set(HSILIBS_DEPENDENCIES
 daq_add_library(HSIEventSender.cpp HSIFrameProcessor.cpp LINK_LIBRARIES ${HSILIBS_DEPENDENCIES})
 
 ##############################################################################
-daq_add_plugin(HSIDataHandlerModule duneDAQModule LINK_LIBRARIES hsilibs datahandlinglibs::datahandlinglibs ${BOOST_LIBS})
-daq_add_plugin(FakeHSIEventGeneratorModule duneDAQModule LINK_LIBRARIES hsilibs timing::timing utilities::utilities)
-daq_add_plugin(HSIReadout duneDAQModule LINK_LIBRARIES timing::timing timinglibs::timinglibs hsilibs appmodel::appmodel)
-daq_add_plugin(HSIController duneDAQModule LINK_LIBRARIES hsilibs timing::timing timinglibs::timinglibs)
+daq_add_plugin(HSIDataHandlerModule duneDAQModule LINK_LIBRARIES hsilibs datahandlinglibs::datahandlinglibs timinglibs::dal ${BOOST_LIBS})
+daq_add_plugin(FakeHSIEventGeneratorModule duneDAQModule LINK_LIBRARIES hsilibs timing::timing  timinglibs::dal utilities::utilities)
+daq_add_plugin(HSIReadout duneDAQModule LINK_LIBRARIES timing::timing hsilibs  timinglibs::dal appmodel::dal)
+daq_add_plugin(HSIController duneDAQModule LINK_LIBRARIES hsilibs dal_hsilibs timing::timing  timinglibs::dal )
 
 ##############################################################################
 
-daq_add_unit_test(HSITypeAdapters_test LINK_LIBRARIES hsilibs ${BOOST_LIBS})
+daq_add_unit_test(HSITypeAdapters_test LINK_LIBRARIES hsilibs dal_hsilibs ${BOOST_LIBS})
 
 ##############################################################################
 daq_install()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ find_package(oks REQUIRED)
 find_package(oksdalgen REQUIRED)
 find_package(conffwk REQUIRED)
 
-add_dal_library(hsi.schema.xml NAMESPACE dunedaq::hsilibs::dal DALDIR dal DEP_PKGS timinglibs confmodel)
+daq_add_dal_library(hsi.schema.xml NAMESPACE dunedaq::hsilibs::dal DALDIR dal DEP_PKGS timinglibs confmodel)
 
 daq_protobuf_codegen( opmon/*.proto )
 
@@ -60,11 +60,11 @@ daq_add_library(HSIEventSender.cpp HSIFrameProcessor.cpp LINK_LIBRARIES ${HSILIB
 daq_add_plugin(HSIDataHandlerModule duneDAQModule LINK_LIBRARIES hsilibs datahandlinglibs::datahandlinglibs timinglibs::dal ${BOOST_LIBS})
 daq_add_plugin(FakeHSIEventGeneratorModule duneDAQModule LINK_LIBRARIES hsilibs timing::timing  timinglibs::dal utilities::utilities)
 daq_add_plugin(HSIReadout duneDAQModule LINK_LIBRARIES timing::timing hsilibs  timinglibs::dal appmodel::dal)
-daq_add_plugin(HSIController duneDAQModule LINK_LIBRARIES hsilibs dal_hsilibs timing::timing  timinglibs::dal )
+daq_add_plugin(HSIController duneDAQModule LINK_LIBRARIES hsilibs hsilibs_dal timing::timing  timinglibs::dal )
 
 ##############################################################################
 
-daq_add_unit_test(HSITypeAdapters_test LINK_LIBRARIES hsilibs dal_hsilibs ${BOOST_LIBS})
+daq_add_unit_test(HSITypeAdapters_test LINK_LIBRARIES hsilibs hsilibs_dal ${BOOST_LIBS})
 
 ##############################################################################
 daq_install()

--- a/cmake/hsilibsConfig.cmake.in
+++ b/cmake/hsilibsConfig.cmake.in
@@ -37,12 +37,19 @@ if (EXISTS ${CMAKE_SOURCE_DIR}/@PROJECT_NAME@)
 message(STATUS "Project \"@PROJECT_NAME@\" will be treated as repo (found in ${CMAKE_SOURCE_DIR}/@PROJECT_NAME@)")
 add_library(@PROJECT_NAME@::@PROJECT_NAME@ ALIAS @PROJECT_NAME@)
 
+add_library(@PROJECT_NAME@::dal_@PROJECT_NAME@ ALIAS dal_@PROJECT_NAME@)
+add_library(@PROJECT_NAME@::dal                ALIAS dal_@PROJECT_NAME@)
+
 else()
 
 message(STATUS "Project \"@PROJECT_NAME@\" will be treated as installed package (found in ${CMAKE_CURRENT_LIST_DIR})")
 set_and_check(targets_file ${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake)
 include(${targets_file})
 
+add_library(@PROJECT_NAME@::dal ALIAS @PROJECT_NAME@::dal_@PROJECT_NAME@)
+
 endif()
+
+
 
 check_required_components(@PROJECT_NAME@)

--- a/cmake/hsilibsConfig.cmake.in
+++ b/cmake/hsilibsConfig.cmake.in
@@ -37,8 +37,8 @@ if (EXISTS ${CMAKE_SOURCE_DIR}/@PROJECT_NAME@)
 message(STATUS "Project \"@PROJECT_NAME@\" will be treated as repo (found in ${CMAKE_SOURCE_DIR}/@PROJECT_NAME@)")
 add_library(@PROJECT_NAME@::@PROJECT_NAME@ ALIAS @PROJECT_NAME@)
 
-add_library(@PROJECT_NAME@::dal_@PROJECT_NAME@ ALIAS dal_@PROJECT_NAME@)
-add_library(@PROJECT_NAME@::dal                ALIAS dal_@PROJECT_NAME@)
+add_library(@PROJECT_NAME@::@PROJECT_NAME@_dal ALIAS @PROJECT_NAME@_dal)
+add_library(@PROJECT_NAME@::dal                ALIAS @PROJECT_NAME@_dal)
 
 else()
 
@@ -46,7 +46,7 @@ message(STATUS "Project \"@PROJECT_NAME@\" will be treated as installed package 
 set_and_check(targets_file ${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake)
 include(${targets_file})
 
-add_library(@PROJECT_NAME@::dal ALIAS @PROJECT_NAME@::dal_@PROJECT_NAME@)
+add_library(@PROJECT_NAME@::dal ALIAS @PROJECT_NAME@::@PROJECT_NAME@_dal)
 
 endif()
 


### PR DESCRIPTION
The following PR enables this package to build on its patch branch against `daq-cmake` `v3.1.0`, which contains changes described in DUNE-DAQ/daq-cmake#155. 

This is only to be merged by Software Coordination. 