### PR TITLE
Johnfreeman/merge fddaq v5.3.2 rc3 a9 into develop

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ find_package(oks REQUIRED)
 find_package(oksdalgen REQUIRED)
 find_package(conffwk REQUIRED)
 
-daq_oks_codegen(hsi.schema.xml NAMESPACE dunedaq::hsilibs::dal DALDIR dal DEP_PKGS timinglibs confmodel)
+add_dal_library(hsi.schema.xml NAMESPACE dunedaq::hsilibs::dal DALDIR dal DEP_PKGS timinglibs confmodel)
 
 daq_protobuf_codegen( opmon/*.proto )
 
@@ -57,14 +57,14 @@ set(HSILIBS_DEPENDENCIES
 daq_add_library(HSIEventSender.cpp HSIFrameProcessor.cpp LINK_LIBRARIES ${HSILIBS_DEPENDENCIES})
 
 ##############################################################################
-daq_add_plugin(HSIDataHandlerModule duneDAQModule LINK_LIBRARIES hsilibs datahandlinglibs::datahandlinglibs ${BOOST_LIBS})
-daq_add_plugin(FakeHSIEventGeneratorModule duneDAQModule LINK_LIBRARIES hsilibs timing::timing utilities::utilities)
-daq_add_plugin(HSIReadout duneDAQModule LINK_LIBRARIES timing::timing timinglibs::timinglibs hsilibs appmodel::appmodel)
-daq_add_plugin(HSIController duneDAQModule LINK_LIBRARIES hsilibs timing::timing timinglibs::timinglibs)
+daq_add_plugin(HSIDataHandlerModule duneDAQModule LINK_LIBRARIES hsilibs datahandlinglibs::datahandlinglibs timinglibs::dal ${BOOST_LIBS})
+daq_add_plugin(FakeHSIEventGeneratorModule duneDAQModule LINK_LIBRARIES hsilibs timing::timing  timinglibs::dal utilities::utilities)
+daq_add_plugin(HSIReadout duneDAQModule LINK_LIBRARIES timing::timing hsilibs  timinglibs::dal appmodel::dal)
+daq_add_plugin(HSIController duneDAQModule LINK_LIBRARIES hsilibs dal_hsilibs timing::timing  timinglibs::dal )
 
 ##############################################################################
 
-daq_add_unit_test(HSITypeAdapters_test LINK_LIBRARIES hsilibs ${BOOST_LIBS})
+daq_add_unit_test(HSITypeAdapters_test LINK_LIBRARIES hsilibs dal_hsilibs ${BOOST_LIBS})
 
 ##############################################################################
 daq_install()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ find_package(oks REQUIRED)
 find_package(oksdalgen REQUIRED)
 find_package(conffwk REQUIRED)
 
-add_dal_library(hsi.schema.xml NAMESPACE dunedaq::hsilibs::dal DALDIR dal DEP_PKGS timinglibs confmodel)
+daq_add_dal_library(hsi.schema.xml NAMESPACE dunedaq::hsilibs::dal DALDIR dal DEP_PKGS timinglibs confmodel)
 
 daq_protobuf_codegen( opmon/*.proto )
 
@@ -60,11 +60,11 @@ daq_add_library(HSIEventSender.cpp HSIFrameProcessor.cpp LINK_LIBRARIES ${HSILIB
 daq_add_plugin(HSIDataHandlerModule duneDAQModule LINK_LIBRARIES hsilibs datahandlinglibs::datahandlinglibs timinglibs::dal ${BOOST_LIBS})
 daq_add_plugin(FakeHSIEventGeneratorModule duneDAQModule LINK_LIBRARIES hsilibs timing::timing  timinglibs::dal utilities::utilities)
 daq_add_plugin(HSIReadout duneDAQModule LINK_LIBRARIES timing::timing hsilibs  timinglibs::dal appmodel::dal)
-daq_add_plugin(HSIController duneDAQModule LINK_LIBRARIES hsilibs dal_hsilibs timing::timing  timinglibs::dal )
+daq_add_plugin(HSIController duneDAQModule LINK_LIBRARIES hsilibs hsilibs_dal timing::timing  timinglibs::dal )
 
 ##############################################################################
 
-daq_add_unit_test(HSITypeAdapters_test LINK_LIBRARIES hsilibs dal_hsilibs ${BOOST_LIBS})
+daq_add_unit_test(HSITypeAdapters_test LINK_LIBRARIES hsilibs hsilibs_dal ${BOOST_LIBS})
 
 ##############################################################################
 daq_install()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.12)
-project(hsilibs VERSION 4.7.0)
+project(hsilibs VERSION 4.8.0)
 
 find_package(daq-cmake REQUIRED)
 

--- a/cmake/hsilibsConfig.cmake.in
+++ b/cmake/hsilibsConfig.cmake.in
@@ -37,12 +37,19 @@ if (EXISTS ${CMAKE_SOURCE_DIR}/@PROJECT_NAME@)
 message(STATUS "Project \"@PROJECT_NAME@\" will be treated as repo (found in ${CMAKE_SOURCE_DIR}/@PROJECT_NAME@)")
 add_library(@PROJECT_NAME@::@PROJECT_NAME@ ALIAS @PROJECT_NAME@)
 
+add_library(@PROJECT_NAME@::dal_@PROJECT_NAME@ ALIAS dal_@PROJECT_NAME@)
+add_library(@PROJECT_NAME@::dal                ALIAS dal_@PROJECT_NAME@)
+
 else()
 
 message(STATUS "Project \"@PROJECT_NAME@\" will be treated as installed package (found in ${CMAKE_CURRENT_LIST_DIR})")
 set_and_check(targets_file ${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake)
 include(${targets_file})
 
+add_library(@PROJECT_NAME@::dal ALIAS @PROJECT_NAME@::dal_@PROJECT_NAME@)
+
 endif()
+
+
 
 check_required_components(@PROJECT_NAME@)

--- a/cmake/hsilibsConfig.cmake.in
+++ b/cmake/hsilibsConfig.cmake.in
@@ -37,8 +37,8 @@ if (EXISTS ${CMAKE_SOURCE_DIR}/@PROJECT_NAME@)
 message(STATUS "Project \"@PROJECT_NAME@\" will be treated as repo (found in ${CMAKE_SOURCE_DIR}/@PROJECT_NAME@)")
 add_library(@PROJECT_NAME@::@PROJECT_NAME@ ALIAS @PROJECT_NAME@)
 
-add_library(@PROJECT_NAME@::dal_@PROJECT_NAME@ ALIAS dal_@PROJECT_NAME@)
-add_library(@PROJECT_NAME@::dal                ALIAS dal_@PROJECT_NAME@)
+add_library(@PROJECT_NAME@::@PROJECT_NAME@_dal ALIAS @PROJECT_NAME@_dal)
+add_library(@PROJECT_NAME@::dal                ALIAS @PROJECT_NAME@_dal)
 
 else()
 
@@ -46,7 +46,7 @@ message(STATUS "Project \"@PROJECT_NAME@\" will be treated as installed package 
 set_and_check(targets_file ${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake)
 include(${targets_file})
 
-add_library(@PROJECT_NAME@::dal ALIAS @PROJECT_NAME@::dal_@PROJECT_NAME@)
+add_library(@PROJECT_NAME@::dal ALIAS @PROJECT_NAME@::@PROJECT_NAME@_dal)
 
 endif()
 


### PR DESCRIPTION
This PR is part of an overall merging of the `patch/fddaq-v5.3.x` branches into `develop` in the wake of release candidate 3 for `fddaq-v5.3.2`; note that the actual source branch, `johnfreeman/merge_fddaq-v5.3.2-rc3-a9_into_develop`, is an intermediary here. A test release was built with the source branch (`NFDT_DEV_250617_A9`) and successful integration tests were run (https://github.com/DUNE-DAQ/daq-release/actions/runs/15717205217). 