### PR TITLE
Modified FakeHSIEventGeneratorModule to make use of the TimeSync conn…

### DIFF
--- a/plugins/FakeHSIEventGeneratorModule.cpp
+++ b/plugins/FakeHSIEventGeneratorModule.cpp
@@ -80,6 +80,11 @@ FakeHSIEventGeneratorModule::init(std::shared_ptr<appfwk::ConfigurationManager> 
     }
   }
 
+  // 07-Jul-2025, KAB: added the fetching of the TimeSync connection information
+  // (and the assignment of the TimeSync Receiver) here, now that we have the
+  // TimeSync connection defined in the configuration.  (Previously, the creation
+  // of the TimeSync receiver was done in the 'start' method, and it used a hard-coded
+  // wildcard in the connection name lookup.)
   for (auto con : mdal->get_inputs()) {
     if (con->get_data_type() == datatype_to_string<dfmessages::TimeSync>()) {
       m_timesync_receiver = get_iom_receiver<dfmessages::TimeSync>(con->UID());

--- a/plugins/FakeHSIEventGeneratorModule.cpp
+++ b/plugins/FakeHSIEventGeneratorModule.cpp
@@ -80,6 +80,12 @@ FakeHSIEventGeneratorModule::init(std::shared_ptr<appfwk::ConfigurationManager> 
     }
   }
 
+  for (auto con : mdal->get_inputs()) {
+    if (con->get_data_type() == datatype_to_string<dfmessages::TimeSync>()) {
+      m_timesync_receiver = get_iom_receiver<dfmessages::TimeSync>(con->UID());
+    }
+  }
+
   m_params = mdal->get_configuration();
   TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << get_name() << ": Exiting init() method";
 }
@@ -137,7 +143,6 @@ FakeHSIEventGeneratorModule::do_start(const nlohmann::json& obj)
 
   m_timestamp_estimator.reset(new utilities::TimestampEstimator(start_params.run, m_clock_frequency));
 
-  m_timesync_receiver = get_iom_receiver<dfmessages::TimeSync>(".*");
   m_timesync_receiver->add_callback(
     std::bind(&utilities::TimestampEstimator::timesync_callback<dfmessages::TimeSync>,
               reinterpret_cast<utilities::TimestampEstimator*>(m_timestamp_estimator.get()),


### PR DESCRIPTION
…ection specified in the configuration (now that we have one) instead of using a hard-coded wildcard.

This PR depends on [appmodel PR 220](https://github.com/DUNE-DAQ/appmodel/pull/220).

That PR in `appmodel` added the TimeSync input connection to FakeHSI applications.  The changes in this PR modify the `FakeHSIEventGeneratorModule` code to make use of that new entry in the configuration.  

It would be great for reviewer(s) to confirm that the code changes look reasonable.

Beyond that, I believe that testing these changes will consist of verifying that they don't break anything.

