### PR TITLE
Fix: Resolve race condition in HSI generator worker thread startup

### DIFF
--- a/plugins/FakeHSIEventGeneratorModule.cpp
+++ b/plugins/FakeHSIEventGeneratorModule.cpp
@@ -145,6 +145,8 @@ FakeHSIEventGeneratorModule::do_start(const CommandData_t& obj)
   TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << get_name() << ": Entering do_start() method";
   auto start_params = obj.get<rcif::cmd::StartParams>();
 
+  m_start_promise = std::make_unique<std::promise<void>>();
+
   m_timestamp_estimator.reset(new utilities::TimestampEstimatorTimeSync(start_params.run, m_clock_frequency));
 
   m_timesync_receiver->add_callback(
@@ -183,6 +185,7 @@ FakeHSIEventGeneratorModule::do_start(const CommandData_t& obj)
   }
 
   m_thread.start_working_thread("fake-tsd-gen");
+  m_start_promise->set_value();  
   TLOG() << get_name() << " successfully started";
   TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << get_name() << ": Exiting do_start() method";
 }
@@ -198,6 +201,8 @@ FakeHSIEventGeneratorModule::do_stop(const CommandData_t& /*args*/)
          << " TimeSync messages.";
 
   m_timestamp_estimator.reset(nullptr); // Calls TimestampEstimatorTimeSync dtor
+
+  m_start_promise.reset(); 
 
   m_active_trigger_rate.store(m_trigger_rate.load());
   m_event_period.store(1.e6 / m_active_trigger_rate.load());
@@ -245,8 +250,11 @@ FakeHSIEventGeneratorModule::do_hsi_work(std::atomic<bool>& running_flag)
 {
   TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << get_name() << ": Entering generate_hsievents() method";
 
-  // Wait for there to be a valid timestsamp estimate before we start
-  // TODO put in tome sort of timeout? Stoyan Trilov stoyan.trilov@cern.ch
+  if (m_start_promise) {
+    auto start_future = m_start_promise->get_future();
+    start_future.wait(); // This blocks until m_start_promise->set_value() is called.
+  }
+
   if (m_timestamp_estimator.get() != nullptr && m_timestamp_estimator->wait_for_valid_timestamp(running_flag) ==
                                                   utilities::TimestampEstimatorBase::kInterrupted) {
     ers::error(utilities::FailedToGetTimestampEstimate(ERS_HERE));

--- a/plugins/FakeHSIEventGeneratorModule.hpp
+++ b/plugins/FakeHSIEventGeneratorModule.hpp
@@ -21,6 +21,7 @@
 
 #include <bitset>
 #include <chrono>
+#include <future>
 #include <memory>
 #include <random>
 #include <string>
@@ -67,6 +68,7 @@ private:
   dunedaq::utilities::WorkerThread m_thread;
 
   std::shared_ptr<iomanager::ReceiverConcept<dfmessages::TimeSync>> m_timesync_receiver;
+  std::unique_ptr<std::promise<void>> m_start_promise;
 
   // Configuration
   std::atomic<daqdataformats::run_number_t> m_run_number;
@@ -74,7 +76,7 @@ private:
   // Helper class for estimating DAQ time
   std::unique_ptr<utilities::TimestampEstimatorTimeSync> m_timestamp_estimator;
 
-  // Random Generatior
+  // Random Generator
   std::default_random_engine m_random_generator;
   std::uniform_int_distribution<uint32_t> m_uniform_distribution; // NOLINT(build/unsigned)
   std::poisson_distribution<uint64_t> m_poisson_distribution;     // NOLINT(build/unsigned)


### PR DESCRIPTION
### Problem
A race condition exists during the startup of the `FakeHSIEventGeneratorModule`. The `do_start` method initializes the TimeSync receiver and then immediately starts the `do_hsi_work` worker thread.

The worker thread's first action is to wait for a TimeSync message. However, there is no guarantee that the receiver is fully configured and ready by the time the worker thread starts waiting. In a scenario where the worker thread starts faster than the receiver can initialize, the first TimeSync message can be missed, potentially leading to a deadlock.

The existence of this race condition was confirmed by adding a temporary sleep at the beginning of the worker thread was sufficient to prevent the deadlock, proving it is a timing issue.

### Solution
This change introduces an explicit synchronization mechanism using `std::promise` and `std::future` to resolve the race condition.

The new workflow is as follows:
- In do_start, a `std::promise` is created before any setup begins.
- The `do_hsi_work` worker thread is started. Its first action is to get the `std::future` from the promise and `wait()` on it, which blocks the thread from proceeding.
- The main thread continues its execution in `do_start`, completing all initialization (setting up the timestamp estimator, adding the receiver callback, etc.).
- Once all setup is complete, do_start calls `set_value()` on the promise.

This action fulfills the future and unblocks the worker thread, which can now safely proceed, guaranteed that all resources are fully initialized.