### PR TITLE
initial changes to adapt to confgen (integtest config params) improvements

### DIFF
--- a/integtest/iceberg_real_hsi_test.py
+++ b/integtest/iceberg_real_hsi_test.py
@@ -77,13 +77,9 @@ if the_global_timing_session_is_running:
 else:
     print(f"DEBUG: hostname is {hostname}, iceberg-computer flag is {we_are_running_on_an_iceberg_computer}, global-timing-running flag is {the_global_timing_session_is_running}, connection-server-running flag is {the_connection_server_is_running}.")
 
-# The next three variable declarations *must* be present as globals in the test
-# file. They're read by the "fixtures" in conftest.py to determine how
-# to run the config generation and drunc
 
-object_databases = ["config/daqsystemtest/integrationtest-objects.data.xml"]
-
-conf_dict = data_classes.drunc_config()
+conf_dict = data_classes.integtest_params_for_generated_dunedaq_config()
+conf_dict.object_databases = ["config/daqsystemtest/integrationtest-objects.data.xml"]
 conf_dict.dro_map_config.n_streams = number_of_data_producers
 conf_dict.dro_map_config.n_apps = number_of_readout_apps
 conf_dict.op_env = "integtest"


### PR DESCRIPTION
# Description

These changes are intended for `fddaq-v5.7.0`.

They need to be tested and merged in conjunction with DUNE-DAQ/integrationtest#155 and branches in other repositories.  Please see the `integrationtest` PR for suggested testing instructions.

The changes in this repository react to, and take advantage of, changes in the `integrationtest` infrastructure that attempt to make it easier to specify and understand the parameters that drive each test. 

## Type of change

- [x] Optimization (non-breaking change that improves code/performance)

## Testing checklist

- [x] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [x] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)
