### PR TITLE
Modified the integtest to support user-requested deletion of HDF5 files at the end of the integtest

### DIFF
--- a/integtest/iceberg_real_hsi_test.py
+++ b/integtest/iceberg_real_hsi_test.py
@@ -196,14 +196,3 @@ def test_data_files(run_dunerc):
             assert data_file_checks.check_fragment_sizes(data_file, fragment_check_list[jdx])
 
 # ### also test the expected trigger bit ###
-
-
-def test_cleanup(run_dunerc):
-    if not we_are_running_on_an_iceberg_computer:
-        pytest.skip(f"This computer ({hostname}) is not part of the ICEBERG DAQ cluster and therefore can not run this test.")
-    if not the_global_timing_session_is_running:
-        pytest.skip("The global timing session is not running.")
-    if not the_connection_server_is_running:
-        pytest.skip(f"The connectivity service must be running for this test.")
-
-    utility_functions.remove_hdf5_files_if_requested(run_dunerc, this_test_requests_hdf5_file_removal=False)

--- a/integtest/iceberg_real_hsi_test.py
+++ b/integtest/iceberg_real_hsi_test.py
@@ -15,8 +15,8 @@ import urllib.request
 
 import integrationtest.data_file_checks as data_file_checks
 import integrationtest.log_file_checks as log_file_checks
-import integrationtest.basic_checks as basic_checks
 import integrationtest.data_classes as data_classes
+import integrationtest.utility_functions as utility_functions
 from integrationtest.verbosity_helper import IntegtestVerbosityLevels
 
 import functools
@@ -148,7 +148,7 @@ def test_dunerc_success(run_dunerc, caplog):
         pytest.skip(f"The connectivity service must be running for this test.")
 
     # check for run control success, problems during pytest setup, etc.
-    basic_checks.basic_checks(run_dunerc, caplog, print_test_name=True)
+    utility_functions.basic_checks(run_dunerc, caplog, print_test_name=True)
 
 def test_log_files(run_dunerc):
     if not we_are_running_on_an_iceberg_computer:
@@ -197,3 +197,6 @@ def test_data_files(run_dunerc):
 
 # ### also test the expected trigger bit ###
 
+
+def test_cleanup(run_dunerc):
+    utility_functions.remove_hdf5_files_if_requested(run_dunerc, this_test_requests_hdf5_file_removal=False)

--- a/integtest/iceberg_real_hsi_test.py
+++ b/integtest/iceberg_real_hsi_test.py
@@ -199,4 +199,11 @@ def test_data_files(run_dunerc):
 
 
 def test_cleanup(run_dunerc):
+    if not we_are_running_on_an_iceberg_computer:
+        pytest.skip(f"This computer ({hostname}) is not part of the ICEBERG DAQ cluster and therefore can not run this test.")
+    if not the_global_timing_session_is_running:
+        pytest.skip("The global timing session is not running.")
+    if not the_connection_server_is_running:
+        pytest.skip(f"The connectivity service must be running for this test.")
+
     utility_functions.remove_hdf5_files_if_requested(run_dunerc, this_test_requests_hdf5_file_removal=False)


### PR DESCRIPTION
# Description

The ability to remove HDF5 files at the end of each integtest (upon user request) was suggested some time ago in discussions about changes to the `integrationtest` infrastructure.  The `integrationtest` code has been modified to support this functionality (DUNE-DAQ/integrationtest#157), and the changes in this PR take advantage of those changes.

These changes should be tested and merged in conjunction with the changes in the `integrationtest` and other repos.  Please see DUNE-DAQ/integrationtest#157 for suggested testing steps.

## Type of change

- [x] Optimization (non-breaking change that improves code/performance)

## Testing checklist

- [x] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [x] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)
