### PR TITLE
wrk: version v4.11.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.12)
-project(hsilibs VERSION 4.10.0)
+project(hsilibs VERSION 4.11.0)
 
 find_package(daq-cmake REQUIRED)
 


### PR DESCRIPTION
# Description

Version bump for `hsilibs`: **v4.10.0 → v4.11.0**, prepared for the **fddaq-v5.7.0** build.

Reference tag: `v4.11.0` (points at commit `495e430c34187a64977264777427dc359127c23d`, the tip of this branch).

Commits in this PR: 1 (`wrk: bump version to v4.11.0`).

## Impact Radius

See release notes below for the full set of changes covered by this version.

## Release Notes

CI/license/integtest housekeeping, and removal of already-dead opmon schema/code.

## Version-file diff

```diff
diff --git a/CMakeLists.txt b/CMakeLists.txt
index 69a4121..1b6c6b1 100644
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.12)
-project(hsilibs VERSION 4.10.0)
+project(hsilibs VERSION 4.11.0)
 
 find_package(daq-cmake REQUIRED)
```

> [!IMPORTANT]
> Tag `v4.11.0` has already been pushed and points at the head commit of this
> branch. **Please merge this PR with a merge commit — do not squash or rebase.**
> Squashing or rebasing would leave the published tag pointing at a commit that
> is not an ancestor of `develop`.

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [x] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking change that improves code/performance)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [ ] Unit tests pass (e.g. `dbt-build --unittest`)
- [ ] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [ ] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

_No testing has been performed by this automated agent as part of this PR; testing status above is left unchecked pending maintainer/reviewer confirmation._

## Further checks

- [ ] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))
